### PR TITLE
Correct language parameter in external links

### DIFF
--- a/content/venue-and-travel/entry-and-visa/index.ko.md
+++ b/content/venue-and-travel/entry-and-visa/index.ko.md
@@ -8,11 +8,11 @@ K-ETA(전자여행허가) 신청이 가능한 경우, 비자 없이 단기간(�
 하지만 출국하시기 전 K-ETA 발급이 여전히 필요합니다. K-ETA는 한번 발급하면 2년간 대한민국 입국에 사용하실 수 있습니다. K-ETA 발급은 처리 및 발급에 최대 72시간이 걸리므로, 적어도 출국 72시간 전에는 신청 하셔야 합니다.
 
 {{< button text="K-ETA 신청 자격 안내 (k-eta.go.kr)" href="https://www.k-eta.go.kr/portal/guide/viewetaalification.do?locale=KO" icon="external-link" >}}
-{{< button text="K-ETA 신청 (k-eta.go.kr)" href="https://www.k-eta.go.kr/portal/apply/viewstep1.do?locale=EN" icon="external-link" >}}
-{{< button text="K-ETA 결과 조회 (k-eta.go.kr)" href="https://www.k-eta.go.kr/portal/apply/viewapplysearch.do?locale=EN" icon="external-link" >}}
+{{< button text="K-ETA 신청 (k-eta.go.kr)" href="https://www.k-eta.go.kr/portal/apply/viewstep1.do?locale=KO" icon="external-link" >}}
+{{< button text="K-ETA 결과 조회 (k-eta.go.kr)" href="https://www.k-eta.go.kr/portal/apply/viewapplysearch.do?locale=KO" icon="external-link" >}}
 
 코로나19 등 감염병과 국제정세 변화 등으로, K-ETA 신청 가능한 국가(또는 지역)이 변경될 수 있습니다.
-신청 하시기 전, K-ETA 웹사이트의 [공지사항](https://www.k-eta.go.kr/portal/board/viewboardlist.do?tmpltNm=notice)도 확인 해 보시기 바랍니다.
+신청 하시기 전, K-ETA 웹사이트의 [공지사항](https://www.k-eta.go.kr/portal/board/viewboardlist.do?tmpltNm=notice&locale=KO)도 확인 해 보시기 바랍니다.
 
 # 비자(사증)
 
@@ -22,14 +22,14 @@ C-3-1 비자의 경우, 비자 초청장이 필요합니다. 확인된 UbuCon As
 ## 비자 지원하기
 보통 아래의 절차를 따라 비자를 지원하시면 되지만, 국가별로 절차나 요구되는 서류에 차이가 있을 수 있습니다. 주변 한국 대사관이나 영사관 웹사이트에서 정확한 정보를 확인 하시기 바랍니다.
 
-1. [대한민국 비자포털 - 각종 신청 서식](https://www.visa.go.kr/openPage.do?MENU_ID=10108)에서 국가, 입국목적(관광 등 단기방문)과 체류기간(90일이하) 를 선택하고, `Visa Navigator START` 버튼을 클릭하여 비자 지원 정보를 확인하세요.
+1. [대한민국 비자포털 - 각종 신청 서식](https://www.visa.go.kr/openPage.do?MENU_ID=10108&LANG_TYPE=KO)에서 국가, 입국목적(관광 등 단기방문)과 체류기간(90일이하) 를 선택하고, `Visa Navigator START` 버튼을 클릭하여 비자 지원 정보를 확인하세요.
 2. 신청하실 비자 유형 (보통 C-3-1 또는 C-3-9) 를 클릭하셔서 신청자격과 첨부서류를 확인하세요.
 3. 표시된 첨부서류와 비자 신청서를 준비하세요. 비자 지원서는 `전자서식(비자지원서)`를 클릭하여 온라인으로 작성할 수 있습니다. `신청서 다운로드`를 클릭하여, 양식을 출력하여 작성도 가능합니다.
 4. 신청서(전자서식이면 바코드 출력, 또는 출력하여 작성한 신청서 양식)와 첨부서류가 모두 준비 되었다면, 가까운 대한민국 대사관이나 영사관을 방문하여 비자 수수료를 결제하고 비자 신청을 접수하세요.
-5. 비자 발급에 몇일에서 몇주 정도 걸립니다, [대한민국 비자포털 - 진행현황 조회 및 출력](https://www.visa.go.kr/openPage.do?MENU_ID=10301)에서 발급 상태나 결과를 확인하실 수 있습니다.
+5. 비자 발급에 몇일에서 몇주 정도 걸립니다, [대한민국 비자포털 - 진행현황 조회 및 출력](https://www.visa.go.kr/openPage.do?MENU_ID=10301&LANG_TYPE=KO)에서 발급 상태나 결과를 확인하실 수 있습니다.
 
-{{< button text="대한민국 비자포털" href="https://www.visa.go.kr/" icon="external-link" >}} 
-{{< button text="근처 대한민국 대사관이나 영사관 검색" href="https://www.visa.go.kr/openPage.do?MENU_ID=10106" icon="external-link" >}}
+{{< button text="대한민국 비자포털" href="https://www.visa.go.kr/?LANG_TYPE=KO" icon="external-link" >}}
+{{< button text="근처 대한민국 대사관이나 영사관 검색" href="https://www.visa.go.kr/openPage.do?MENU_ID=10106&LANG_TYPE=KO" icon="external-link" >}}
 
 # 코로나19 방역 정책
 
@@ -40,7 +40,7 @@ C-3-1 비자의 경우, 비자 초청장이 필요합니다. 확인된 UbuCon As
 
 코로나19 음성 확인서를 지참하지 않으면 출국할 수 없습니다.
 
-{{< button text="대상자별 방역 조치" href="https://cov19ent.kdca.go.kr/cpassportal/biz/beffatstmnt/QuarantineMeasuresByType.do" icon="external-link" >}}
+{{< button text="대상자별 방역 조치" href="https://cov19ent.kdca.go.kr/cpassportal/biz/beffatstmnt/QuarantineMeasuresByType.do?lang=ko" icon="external-link" >}}
 {{< button text="해외입국자 방역관리 안내" href="https://ncv.kdca.go.kr/menu.es?mid=a30901000000" icon="external-link" >}}
 
 ## 입국 후
@@ -48,6 +48,6 @@ C-3-1 비자의 경우, 비자 초청장이 필요합니다. 확인된 UbuCon As
 - 입국 심사 후, 입국일로부터 1일 이내 코로나19 PCR 검사를 해야 합니다. 인천국제공항에 도착 하시는 경우 Safe2GO pass 에서 검사를 예약하고 공항에서 검사를 받으실 수 있습니다.
 - 대한민국에 6~7일 이상 머무시는 경우, 입국 6~7일 차에 코로나19 RAT 검사를 하시는 것을 권장합니다.
 
-{{< button text="검역 정보 입력 (Q-CODE)" href="https://cov19ent.kdca.go.kr/cpassportal/?lang=en" icon="external-link" >}}
-{{< button text="한국에서 받을 코로나19 PCR 검사 예약 (Safe2GO pass)" href="https://safe2gopass.com/index" icon="external-link" >}}
+{{< button text="검역 정보 입력 (Q-CODE)" href="https://cov19ent.kdca.go.kr/cpassportal/?lang=ko" icon="external-link" >}}
+{{< button text="한국에서 받을 코로나19 PCR 검사 예약 (Safe2GO pass)" href="https://safe2gopass.com/" icon="external-link" >}}
 

--- a/content/venue-and-travel/entry-and-visa/index.md
+++ b/content/venue-and-travel/entry-and-visa/index.md
@@ -17,20 +17,20 @@ Please also check their [notice board](https://www.k-eta.go.kr/portal/board/view
 # Visa
 
 If you are not eligible for K-ETA, It means you need to issue a visa to visit Republic of Korea. In most cases, C-3 visas (C-3-1 Short-Term General or C-3-9 Ordinary Tourist) should be sufficient for participating UbuCon Asia on-site.  
-For C-3-1 visa, You will need a visa invitation letter. For approved UbuCon Asia participants, [Ubuntu Korea Community](https://ubuntu-kr.org) may try to provide visa invitation letter for visa application. Contact travel@ubucon.asia for more details.
+For C-3-1 visa, You will need a visa invitation letter. For approved UbuCon Asia participants, [Ubuntu Korea Community](https://ubuntu-kr.org/en/) may try to provide visa invitation letter for visa application. Contact travel@ubucon.asia for more details.
 
 
 ## Applying for Visa
 Usually, You will follow following steps to apply for visa, But process or required documents might vary by your country. Make sure to check your local Korean Embassy or Consulate website for accurate information.
 
-1. Visit [Application Form page at KOREA VISA PROTAL website](https://www.visa.go.kr/openPage.do?MENU_ID=10108) and choose your country, entry purpose(Short Term visit) and how long you will stay(90 days or less). Then click `Visa Navigator START` button to see visa application information.
+1. Visit [Application Form page at KOREA VISA PROTAL website](https://www.visa.go.kr/openPage.do?MENU_ID=10108&LANG_TYPE=EN) and choose your country, entry purpose(Short Term visit) and how long you will stay(90 days or less). Then click `Visa Navigator START` button to see visa application information.
 2. Click type of visa you plan to apply (usually either C-3-1 or C-3-9) to see eligibility and required documents.
 3. Prepare required document listed on the website. For Visa application, you may fill in the online form and submit by clicking `e-Form(Visa Application)` button. You may also print out the application form by clicking `Downlaod Form` button.
 4. Once you prepared required documents and visa application (either barcode printout for e-Form or application form printout), Visit local Korean Embassy or Consulate, pay visa fee and apply for Visa.
-5. It may take few days or weeks to issue visa, You may chck [Check Application Status & Print page on KOREA VISA PROTAL website](https://www.visa.go.kr/openPage.do?MENU_ID=10301) to check status or result.
+5. It may take few days or weeks to issue visa, You may chck [Check Application Status & Print page on KOREA VISA PROTAL website](https://www.visa.go.kr/openPage.do?MENU_ID=10301&LANG_TYPE=EN) to check status or result.
 
-{{< button text="Korea Visa Portal" href="https://www.visa.go.kr/" icon="external-link" >}} 
-{{< button text="Find local Korean Embassy or Consulate" href="https://www.visa.go.kr/openPage.do?MENU_ID=10106" icon="external-link" >}}
+{{< button text="Korea Visa Portal" href="https://www.visa.go.kr/?LANG_TYPE=EN" icon="external-link" >}}
+{{< button text="Find local Korean Embassy or Consulate" href="https://www.visa.go.kr/openPage.do?MENU_ID=10106&LANG_TYPE=EN" icon="external-link" >}}
 # COVID-19 Quarantine policy
 
 ## Before departing
@@ -40,7 +40,7 @@ Quarantine is not currently required for anyone who visits Republic of Korea for
 
 If you don't bring valid COVID-19 test result document, You won't be able to depart from your country.
 
-{{< button text="Quarantine for Each Target Person" href="https://cov19ent.kdca.go.kr/cpassportal/biz/beffatstmnt/QuarantineMeasuresByType.do" icon="external-link" >}}
+{{< button text="Quarantine for Each Target Person" href="https://cov19ent.kdca.go.kr/cpassportal/biz/beffatstmnt/QuarantineMeasuresByType.do?lang=en" icon="external-link" >}}
 {{< button text="Qurantine policy for people arrived from overseas(Korean)" href="https://ncv.kdca.go.kr/menu.es?mid=a30901000000" icon="external-link" >}}
 
 ## After arrival
@@ -49,5 +49,5 @@ If you don't bring valid COVID-19 test result document, You won't be able to dep
 - If you plan to stay in Korea more then 6~7 days, It is recommended to conduct COVID-19 RAT test on 6~7th day of arrival.
 
 {{< button text="Enter quarintine information (Q-CODE)" href="https://cov19ent.kdca.go.kr/cpassportal/?lang=en" icon="external-link" >}}
-{{< button text="Book COVID-19 PCR test at Korea (Safe2GO pass)" href="https://safe2gopass.com/index" icon="external-link" >}}
+{{< button text="Book COVID-19 PCR test at Korea (Safe2GO pass)" href="https://safe2gopass.com/" icon="external-link" >}}
 


### PR DESCRIPTION
I corrected the multi-lingual hyperlinks' language parameter to match with UCA 2022 web language.

Affected pages:
 * [`/venue-and-travel/entry-and-visa/`](https://2022.ubucon.asia/venue-and-travel/entry-and-visa/)
 * [`/ko/venue-and-travel/entry-and-visa/`](https://2022.ubucon.asia/ko/venue-and-travel/entry-and-visa/)